### PR TITLE
simple cov for local tests clode climate for deployments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ group :development, :test do
   gem 'chromedriver-helper'
   gem 'database_cleaner'
   gem 'simplecov', require: false
-  gem "codeclimate-test-reporter", require: nil
+  gem 'codeclimate-test-reporter', require: nil
   gem 'web-console', '~> 2.0'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -262,6 +262,3 @@ DEPENDENCIES
   simplecov
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
-
-BUNDLED WITH
-   1.10.3

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,5 +1,3 @@
-require "simplecov"
-SimpleCov.start
 
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
@@ -42,4 +40,5 @@ RSpec.configure do |config|
   config.after(:each) do
     DatabaseCleaner.clean
   end
+
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,3 @@
-require "codeclimate-test-reporter"
-CodeClimate::TestReporter.start
-
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
@@ -53,5 +50,16 @@ RSpec.configure do |config|
 
     click_link "Sign Out"
     expect(page).to have_content("Sign In")
+  end
+
+  # Test Coverage tools
+  # https://github.com/codeclimate/ruby-test-reporter/issues/61
+  # http://docs.travis-ci.com/user/environment-variables/
+  if ENV['CI']
+    require 'codeclimate-test-reporter'
+    CodeClimate::TestReporter.start
+  else
+    require 'simplecov'
+    SimpleCov.start
   end
 end


### PR DESCRIPTION
Updating code coverage tools to run simple cov in dev and code climate on deployment. I couldn't think of a way to test it with out creating a pull request and having travis run it. 