### PR TITLE
62 admin items index

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -15,7 +15,7 @@ class Item < ActiveRecord::Base
 
   validates :name, uniqueness: true
 
-  enum role: %w(default admin)
+  enum status: %w(active retired)
 
   def default_image
     if image_url.nil? || image_url.empty?

--- a/db/migrate/20150812180808_add_status_column_to_items.rb
+++ b/db/migrate/20150812180808_add_status_column_to_items.rb
@@ -1,0 +1,5 @@
+class AddStatusColumnToItems < ActiveRecord::Migration
+  def change
+    add_column :items, :status, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150812134059) do
+ActiveRecord::Schema.define(version: 20150812180808) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -26,8 +26,8 @@ ActiveRecord::Schema.define(version: 20150812134059) do
     t.decimal  "price",       precision: 10, scale: 2
     t.datetime "created_at",                                       null: false
     t.datetime "updated_at",                                       null: false
-    t.integer  "category_id"
     t.string   "image_url"
+    t.integer  "category_id"
     t.integer  "status",                               default: 0
   end
 

--- a/spec/features/admin_items_index_spec.rb
+++ b/spec/features/admin_items_index_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.describe "an admin on their dashboards" do
   let!(:user) { Fabricate(:user) }
   let!(:item) { Fabricate(:item) }
+  let!(:second_item) { item }
 
   before(:each) do
     sign_in(user)
@@ -10,6 +11,8 @@ RSpec.describe "an admin on their dashboards" do
   end
 
   it "can see all items" do
+    second_item.update_attributes(name: "Burger", status: 1)
+
     visit "/admin/dashboard"
     click_link "View All Items"
 
@@ -18,8 +21,13 @@ RSpec.describe "an admin on their dashboards" do
     expect(page).to have_content("Description")
     expect(page).to have_content("Price")
     expect(page).to have_content("Status")
+
     expect(page).to have_content(item.name)
     expect(page).to have_content(item.description)
     expect(page).to have_content(item.price.to_s)
+    expect(page).to have_content(item.status)
+
+    expect(page).to have_content(second_item.name)
+    expect(page).to have_content(second_item.status)
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -32,6 +32,16 @@ RSpec.describe "the item", type: :model do
       item.category_id = nil
       expect(item).to_not be_valid
     end
+
+    it "knows if item was retired" do
+      item.status = 1
+      expect(item.retired?).to be true
+    end
+
+    it "knows if item was active" do
+      item.status = 0
+      expect(item.active?).to be true
+    end
   end
 end
 


### PR DESCRIPTION
closes #62 

- As an Admin
- When I visit "/admin/dashboard"
- Then I should see a link for viewing all items
- And when I click that link
- Then I should see a table with all items (active and inactive)
- And each item should have:

- A thumbnail of the image
- Title that links to the item
- Description
- Status
- Actions (Edit)